### PR TITLE
fix url handling for us-east-1 region

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -78,6 +78,11 @@ def parse_url(url):
     if m:
         return (m.group(2), m.group(3), m.group(4))
 
+    # http[s]://<bucket>.s3.<aws-region>.amazonaws.com
+    m = re.match(r'(http|https|s3)://([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])[.]s3[.]([a-z0-9-]+)[.]amazonaws[.]com(.*)$', url)
+    if m:
+        return (m.group(2), m.group(3), m.group(4))
+
     # http[s]://s3.amazonaws.com/<bucket>
     m = re.match(r'(http|https|s3)://s3[.]amazonaws[.]com/([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])(.*)$', url)
     if m:
@@ -144,7 +149,7 @@ class S3Repository(YumRepository):
             elif 'cn-northwest-1' in region:
                 self.baseurl = "https://%s.s3.cn-northwest-1.amazonaws.com.cn%s" % (bucket, path)
         else:
-            self.baseurl = "https://%s.s3.amazonaws.com%s" % (bucket, path)
+            self.baseurl = "https://%s.s3.%s.amazonaws.com%s" % (bucket, region, path)
 
         self.name = repo.name
         self.region = repo.region if repo.region else region


### PR DESCRIPTION
**What does this change accomplish?**
The yum-s3-iam plugin version we are using was released 5 years ago. The latest version doesn't handle the current S3 bucket URL we're using in us-east-1. This change added support to handle current S3 bucket URL in us-east-1 region.

**How was this change tested?**
Launched grafana and tapp-gibbon instances with this plugin installed from this feature branch. Papply finished without failures.