### PR TITLE
Fix S3 bucket url handling

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -104,7 +104,7 @@ def parse_url(url):
         return (m.group(3), m.group(2), m.group(4))
 
     # http[s]://<bucket_with_domain>/<path> # to handle fitpay domain cases
-    m = re.match(r'(http|https|s3)://([a-z0-9-.]+)[/](.*)$', url)
+    m = re.match(r'(http|https|s3)://([a-z0-9-.]+)/(.*)$', url)
     if m:
         return (m.group(2), None, m.group(3))    
 
@@ -149,12 +149,14 @@ class S3Repository(YumRepository):
 
         if region and region != 'us-east-1':
             self.baseurl = "https://s3-%s.amazonaws.com/%s%s" % (region, bucket, path)
-            if 'cn-north-1' in region:
-                self.baseurl = "https://s3.cn-north-1.amazonaws.com.cn/%s%s" % (bucket, path)
+            if '.' in bucket:
+                self.baseurl = "https://%s%s" % (bucket, path)
             elif 'cn-northwest-1' in region:
                 self.baseurl = "https://%s.s3.cn-northwest-1.amazonaws.com.cn%s" % (bucket, path)
+            elif 'cn-north-1' in region:
+                self.baseurl = "https://s3.cn-north-1.amazonaws.com.cn/%s%s" % (bucket, path)
         elif '.' in bucket:
-            baseurl = "https://%s/%s" % (bucket, path)
+            self.baseurl = "https://%s%s" % (bucket, path)
         else:
             self.baseurl = "https://%s.s3.%s.amazonaws.com%s" % (bucket, region, path)
 

--- a/s3iam.py
+++ b/s3iam.py
@@ -78,7 +78,7 @@ def parse_url(url):
     if m:
         return (m.group(2), m.group(3), m.group(4))
 
-    #http[s]://<bucket>.s3.<aws-region>.amazonaws.com
+    # http[s]://<bucket>.s3.<aws-region>.amazonaws.com
     m = re.match(r'(http|https|s3)://([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])[.]s3[.]([a-z0-9-]+)[.]amazonaws[.]com(.*)$', url)
     if m and 'cn' not in m.group(3):
         return (m.group(2), m.group(3), m.group(4))

--- a/s3iam.py
+++ b/s3iam.py
@@ -147,16 +147,16 @@ class S3Repository(YumRepository):
             msg = "s3iam: unable to parse url %s'" % repo.baseurl
             raise yum.plugins.PluginYumExit(msg)
 
-        if region and region != 'us-east-1':
+        if '.' in bucket:
+            self.baseurl = "https://%s%s" % (bucket, path)
+        elif region and region != 'us-east-1':
             self.baseurl = "https://s3-%s.amazonaws.com/%s%s" % (region, bucket, path)
-            if '.' in bucket:
-                self.baseurl = "https://%s%s" % (bucket, path)
-            elif 'cn-northwest-1' in region:
+            if 'cn-northwest-1' in region:
                 self.baseurl = "https://%s.s3.cn-northwest-1.amazonaws.com.cn%s" % (bucket, path)
             elif 'cn-north-1' in region:
                 self.baseurl = "https://s3.cn-north-1.amazonaws.com.cn/%s%s" % (bucket, path)
-        elif '.' in bucket:
-            self.baseurl = "https://%s%s" % (bucket, path)
+        elif region == None:
+            self.baseural = "https://%s.s3.amazonaws.com%s" % (bucket, path)
         else:
             self.baseurl = "https://%s.s3.%s.amazonaws.com%s" % (bucket, region, path)
 

--- a/s3iam.py
+++ b/s3iam.py
@@ -78,10 +78,10 @@ def parse_url(url):
     if m:
         return (m.group(2), m.group(3), m.group(4))
 
-    # http[s]://<bucket>.s3.<aws-region>.amazonaws.com
-    # m = re.match(r'(http|https|s3)://([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])[.]s3[.]([a-z0-9-]+)[.]amazonaws[.]com(.*)$', url)
-    # if m:
-    #     return (m.group(2), m.group(3), m.group(4))
+    #http[s]://<bucket>.s3.<aws-region>.amazonaws.com
+    m = re.match(r'(http|https|s3)://([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])[.]s3[.]([a-z0-9-]+)[.]amazonaws[.]com(.*)$', url)
+    if m and 'cn' not in m.group(3):
+        return (m.group(2), m.group(3), m.group(4))
 
     # http[s]://s3.amazonaws.com/<bucket>
     m = re.match(r'(http|https|s3)://s3[.]amazonaws[.]com/([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])(.*)$', url)
@@ -148,8 +148,10 @@ class S3Repository(YumRepository):
                 self.baseurl = "https://s3.cn-north-1.amazonaws.com.cn/%s%s" % (bucket, path)
             elif 'cn-northwest-1' in region:
                 self.baseurl = "https://%s.s3.cn-northwest-1.amazonaws.com.cn%s" % (bucket, path)
-        else:
+        elif region == None:
             self.baseurl = "https://%s.s3.amazonaws.com%s" % (bucket, path)
+        else:
+            self.baseurl = "https://%s.s3.%s.amazonaws.com%s" % (bucket, region, path)
 
         self.name = repo.name
         self.region = repo.region if repo.region else region

--- a/s3iam.py
+++ b/s3iam.py
@@ -79,9 +79,9 @@ def parse_url(url):
         return (m.group(2), m.group(3), m.group(4))
 
     # http[s]://<bucket>.s3.<aws-region>.amazonaws.com
-    m = re.match(r'(http|https|s3)://([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])[.]s3[.]([a-z0-9-]+)[.]amazonaws[.]com(.*)$', url)
-    if m:
-        return (m.group(2), m.group(3), m.group(4))
+    # m = re.match(r'(http|https|s3)://([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])[.]s3[.]([a-z0-9-]+)[.]amazonaws[.]com(.*)$', url)
+    # if m:
+    #     return (m.group(2), m.group(3), m.group(4))
 
     # http[s]://s3.amazonaws.com/<bucket>
     m = re.match(r'(http|https|s3)://s3[.]amazonaws[.]com/([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])(.*)$', url)
@@ -149,7 +149,7 @@ class S3Repository(YumRepository):
             elif 'cn-northwest-1' in region:
                 self.baseurl = "https://%s.s3.cn-northwest-1.amazonaws.com.cn%s" % (bucket, path)
         else:
-            self.baseurl = "https://%s.s3.%s.amazonaws.com%s" % (bucket, region, path)
+            self.baseurl = "https://%s.s3.amazonaws.com%s" % (bucket, path)
 
         self.name = repo.name
         self.region = repo.region if repo.region else region

--- a/s3iam.py
+++ b/s3iam.py
@@ -103,6 +103,11 @@ def parse_url(url):
     if m:
         return (m.group(3), m.group(2), m.group(4))
 
+    # http[s]://<bucket_with_domain>/<path> # to handle fitpay domain cases
+    m = re.match(r'(http|https|s3)://([a-z0-9-.]+)[/](.*)$', url)
+    if m:
+        return (m.group(2), None, m.group(3))    
+
     return (None, None, None)
 
 
@@ -148,8 +153,8 @@ class S3Repository(YumRepository):
                 self.baseurl = "https://s3.cn-north-1.amazonaws.com.cn/%s%s" % (bucket, path)
             elif 'cn-northwest-1' in region:
                 self.baseurl = "https://%s.s3.cn-northwest-1.amazonaws.com.cn%s" % (bucket, path)
-        elif region == None:
-            self.baseurl = "https://%s.s3.amazonaws.com%s" % (bucket, path)
+        elif '.' in bucket:
+            baseurl = "https://%s/%s" % (bucket, path)
         else:
             self.baseurl = "https://%s.s3.%s.amazonaws.com%s" % (bucket, region, path)
 


### PR DESCRIPTION
**What does this change accomplish?**
- Fixed plugin failure in CN region caused by the CN S3 URLs fell into the URL handling condition for the US region
- Fixed the Certificate errors when the bucket name has dots by updating S3 URL handling: when parsing S3 URLs with domain on bucket name (e.g., `https://garminpay-artifacts-qa-cn-northwest-1.qa.fitpay.ninja.s3.cn-northwest-1.amazonaws.com.cn/yumrpo/centos`), the scripts return `https://garminpay-artifacts-qa-cn-northwest-1.qa.fitpay.ninja/yumrpo/centos` to hit the Cloudflare CNAME entry. 

**Notes:** The solution in this [issue](https://github.com/seporaitis/yum-s3-iam/issues/47) doesn't work for buckets that are created after 9/30/2020 due to [the deprecation of path-style URL](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/)

**How was this change implemented?**
- Added new URL handling block for S3 bucket name with dots (bucket name with domain included)
**How was this change tested?**
- Launched ZK nodes and rabbitmq nodes in cn-northwest-1 region (@brianmaresca helped check on rabbitmq nodes) by pointing to this feature branch in bootstrap script without getting yum repo errors
- Tested parse_url function and the condition scripts (start from line 150) with various bucket URLs listed below locally. The URLs parse correctly 
`# https://garminpay-artifacts-qa-cn-northwest-1.qa.fitpay.ninja.s3.cn-northwest-1.amazonaws.com.cn/yumrpo/centos
# https://garminpay-artifacts-qa-cn-northwest-1.qa.fitpay.ninja/yumrpo
# https://fpctrl-exhibitor.s3.cn-northwest-1.amazonaws.com.cn/std-qa
# https://s3.cn-northwest-1.amazonaws.com.cn/garminpay-artifacts-qa-cn-northwest-1.qa.fitpay.ninja/yumrepo/centos
# https://s3.amazonaws.com/cftest.fitpay.ninja/test.json
# https://s3.amazonaws.com/demo.fliptopay.com/01/index.html
# https://fpctrl-prod-yumrepo-us-east-1.s3.amazonaws.com/java`
